### PR TITLE
On branch edburns-msft-20240508-post-jug-test Small usability improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,45 @@ A super simple Java project that utilizes DALL-E3, LangChain4J, and Azure Open A
     ```bash
     git clone https://github.com/sandraahlgrimm/langchain4j-dalle3-demo.git
     ```
+    
+    These instructions were tested to work with the code as of tag `20240508`. The instructions should work with the `HEAD` commit, but if you run into problems, try checking out the tag.
 
-2. Create an Azure Open AI account and get the required credentials:
+2. Create an Azure Open AI account and get the required credentials.
+
+   1. In a new tab, visit [Create and deploy an Azure OpenAI Service resource](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource?pivots=web-portal).
+   1. If you want to use the following steps, select the **Portal** tab. Otherwise, just follow the documentation to get the following environment variable values in the way best suited to your needs.
+
+      - `AZURE_OPENAI_ENDPOINT`: Your Azure OpenAI Endpoint.
+      - `AZURE_OPENAI_DEPLOYMENT_NAME`: Your Azure Open AI Deployment name.
+      - `AZURE_OPENAI_API_KEY`: Your Azure Open AI API key.
+      
+   1. Follow the steps up to and including the section **Deploy a model**.
+   
+   1. When you get to the step asking you to **Create new deployment**, use the following substitutions.
+   
+      1. For **Select a model** select **dall-e-3**.
+      1. For **Deployment name** use the same value as your resource group name.
 
     - [Azure Open AI Documentation](https://learn.microsoft.com/azure/ai-services/openai/how-to/create-resource?pivots=cli)
- 
-3. Set up the environment variables in an `.env` file in the root directory of the project with the following content:
 
-    - `AZURE_OPENAI_ENDPOINT`: Your Azure OpenAI Endpoint.
-    - `AZURE_OPENAI_DEPLOYMENT_NAME`: Your Azure Open AI Deployment name.
-    - `AZURE_OPENAI_API_KEY`: Your Azure Open AI API key.
+    1. Ensure the checkmark next to your deployment is selected and select **Open in playground**.
+    1. Select **View code**. Keep this screen open and proceed.
+ 
+3. Set up the environment variables in an `.env` file in the root directory of the project with the following content. Adjust the syntax for your operating system if it is not [POSIX compliant](https://posix.opengroup.org/).
+
+```bash
+export AZURE_OPENAI_ENDPOINT=<select the copy icon on the Endpoint in Azure AI Studio playground>
+export AZURE_OPENAI_DEPLOYMENT_NAME=<your resource group name>
+export AZURE_OPENAI_API_KEY=<select the copy icon on the API key in Azure AI Studio>
+```
+
+   Ensure the `.env` file is evaluated in the shell in which you run the following steps.  To verify the values are set, you can run a command such as `printenv | grep AZURE`.
 
 3. Run the Java App within CodeSpaces, VS Code, IntelliJ IDEA or the IDE of your choice.
 
 ![Screenshot of the executed project highlighting the RUN button](./images/screenshot-run-image-creation.png)
+
+   Alternatively, run in the shell with `mvn clean install exec:java`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ A super simple Java project that utilizes DALL-E3, LangChain4J, and Azure Open A
     ```bash
     git clone https://github.com/sandraahlgrimm/langchain4j-dalle3-demo.git
     ```
-    
-    These instructions were tested to work with the code as of tag `20240508`. The instructions should work with the `HEAD` commit, but if you run into problems, try checking out the tag.
 
 2. Create an Azure Open AI account and get the required credentials.
 
@@ -45,7 +43,7 @@ A super simple Java project that utilizes DALL-E3, LangChain4J, and Azure Open A
 
 ```bash
 export AZURE_OPENAI_ENDPOINT=<select the copy icon on the Endpoint in Azure AI Studio playground>
-export AZURE_OPENAI_DEPLOYMENT_NAME=<your resource group name>
+export AZURE_OPENAI_DEPLOYMENT_NAME=<your openai deployment name>
 export AZURE_OPENAI_API_KEY=<select the copy icon on the API key in Azure AI Studio>
 ```
 
@@ -55,7 +53,7 @@ export AZURE_OPENAI_API_KEY=<select the copy icon on the API key in Azure AI Stu
 
 ![Screenshot of the executed project highlighting the RUN button](./images/screenshot-run-image-creation.png)
 
-   Alternatively, run in the shell with `mvn clean install exec:java`
+   Alternatively, run in the shell with `mvn clean package exec:exec`
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,23 @@
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.6.0</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>java</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <mainClass>com.example.App</mainClass>
+          </configuration>
+        </plugin>
+        
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,7 @@
   <artifactId>demo</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <name>demo</name>
-  <!-- FIXME change it to the project's website -->
-  <url>http://www.example.com</url>
+  <name>lanchain4j-dalle3-demo</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -96,18 +94,16 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>1.6.0</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>java</goal>
-              </goals>
-            </execution>
-          </executions>
           <configuration>
-            <mainClass>com.example.App</mainClass>
+            <executable>java</executable>
+            <arguments>
+              <argument>-cp</argument>
+              <classpath/>
+              <argument>com.example.App</argument>
+            </arguments>
           </configuration>
         </plugin>
-        
+              
       </plugins>
     </pluginManagement>
   </build>

--- a/src/main/java/com/example/App.java
+++ b/src/main/java/com/example/App.java
@@ -28,7 +28,6 @@ public class App
         System.out.println(response.toString());
         Image image = response.content();
         System.out.println("The generated image is here: " + image.url());
-        System.exit(0);
     }
     
 }

--- a/src/main/java/com/example/App.java
+++ b/src/main/java/com/example/App.java
@@ -28,6 +28,7 @@ public class App
         System.out.println(response.toString());
         Image image = response.content();
         System.out.println("The generated image is here: " + image.url());
+        System.exit(0);
     }
     
 }


### PR DESCRIPTION
modified:   README.md

- More explicit guidance

modified:   pom.xml

- Add maven exec plugin.

modified:   src/main/java/com/example/App.java

- Add `System.exit(0)`. I was getting this awful error without it.

```
The generated image is here: https://dalleproduse.blob.core.windows.net/private/images/81f63e67-1da5-4981-a600-f1133f17a6f7/generated_00.png?se=2024-05-10T01%3A01%3A54Z&sig=eA6ytPDkb0YfzAf2c0rceo8QhvuwQXg%2F3%2BCVdSJDLm8%3D&ske=2024-05-15T22%3A33%3A06Z&skoid=09ba021e-c417-441c-b203-c81e5dcd7b7f&sks=b&skt=2024-05-08T22%3A33%3A06Z&sktid=33e01921-4d64-4f8c-a055-5bdaffd5e33d&skv=2020-10-02&sp=r&spr=https&sr=b&sv=2020-10-02;;
[WARNING] thread Thread[reactor-http-nio-1,5,com.example.App] was interrupted but is still alive after waiting at least 15000msecs
[WARNING] thread Thread[reactor-http-nio-1,5,com.example.App] will linger despite being asked to die via interruption
[WARNING] thread Thread[reactor-http-nio-2,5,com.example.App] will linger despite being asked to die via interruption
[WARNING] thread Thread[reactor-http-nio-3,5,com.example.App] will linger despite being asked to die via interruption
[WARNING] thread Thread[reactor-http-nio-4,5,com.example.App] will linger despite being asked to die via interruption
[WARNING] thread Thread[reactor-http-nio-5,5,com.example.App] will linger despite being asked to die via interruption
[WARNING] thread Thread[reactor-http-nio-6,5,com.example.App] will linger despite being asked to die via interruption
[WARNING] thread Thread[reactor-http-nio-7,5,com.example.App] will linger despite being asked to die via interruption
[WARNING] thread Thread[reactor-http-nio-8,5,com.example.App] will linger despite being asked to die via interruption
[WARNING] thread Thread[reactor-http-nio-9,5,com.example.App] will linger despite being asked to die via interruption
[WARNING] thread Thread[reactor-http-nio-10,5,com.example.App] will linger despite being asked to die via interruption
[WARNING] NOTE: 10 thread(s) did not finish despite being asked to  via interruption. This is not a problem with exec:java, it is a problem with the running code. Although not serious, it should be remedied.
[WARNING] Couldn't destroy threadgroup org.codehaus.mojo.exec.ExecJavaMojo$IsolatedThreadGroup[name=com.example.App,maxpri=10]
java.lang.IllegalThreadStateException
    at java.lang.ThreadGroup.destroy (ThreadGroup.java:803)
    at org.codehaus.mojo.exec.ExecJavaMojo.execute (ExecJavaMojo.java:321)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:283)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:226)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:407)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:348)
```